### PR TITLE
support for the multi-nested query

### DIFF
--- a/src/ElasticSearchQuery.php
+++ b/src/ElasticSearchQuery.php
@@ -170,10 +170,16 @@ class ElasticSearchQuery implements \JsonSerializable
         if (!$this->nested_fields)
             return $filter;
 
+        $is_nested = false;
+
         foreach ($this->nested_fields as $nested_field) {
             if (preg_match("#^".preg_quote($nested_field, '#')."#", $field)) {
+                $is_nested = true;
                 break;
             }
+        }
+
+        if (!$is_nested) {
             return $filter;
         }
 


### PR DESCRIPTION
if the first field used isn't the first nested value of `$this->nested_fields`, the path for a nested value isn't use.

My modification permite to check all fields same if the fisrt  nested_fields isn't the same of the current fields.